### PR TITLE
Add image_alt to update_params

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -413,6 +413,7 @@ db/migrate/20190208151235_add_text_filter_name_fields.rb
 db/migrate/20190208152646_move_text_filter_to_name.rb
 db/migrate/20190209155717_remove_text_filter_ids.rb
 db/migrate/20190209160610_remove_text_filters.rb
+db/migrate/20220815155148_add_image_alt_field_to_contents_table.rb
 db/seeds.rb
 lib/email_notify.rb
 lib/format.rb

--- a/app/controllers/admin/content_controller.rb
+++ b/app/controllers/admin/content_controller.rb
@@ -179,14 +179,15 @@ class Admin::ContentController < Admin::BaseController
              :allow_pings,
              :body,
              :body_and_extended,
-             :resource_id,
              :draft,
+             :excerpt,
              :extended,
+             :image_alt,
+             :keywords,
              :permalink,
              :published_at,
-             :title,
-             :keywords,
-             :excerpt)
+             :resource_id,
+             :title)
   end
 
   def default_text_filter


### PR DESCRIPTION
- Add `image_alt` to `update_params` so that it can be updated after article creation
- Reordered attributes alphabetically
- Updated manifest via `rake manifest:create` task to pickup last missed migration

** **IMPORTANT**: Please remember to update version before merge, then tag release afterward.